### PR TITLE
cvmfsexec: Suppress file name prefix in grep for CVMFS_CONFIG_REPOSITORY

### DIFF
--- a/cvmfsexec
+++ b/cvmfsexec
@@ -74,7 +74,7 @@ fi
 shift
 
 # Add the config repo if not already asked for
-CONFIG_REPO="`grep '^CVMFS_CONFIG_REPOSITORY=' $HERE/dist/etc/cvmfs/default.d/*.conf 2>/dev/null|tail -1|sed 's/^CVMFS_CONFIG_REPOSITORY=//'`"
+CONFIG_REPO="`grep -h '^CVMFS_CONFIG_REPOSITORY=' $HERE/dist/etc/cvmfs/default.d/*.conf 2>/dev/null|tail -1|sed 's/^CVMFS_CONFIG_REPOSITORY=//'`"
 if [[ " $REPOS " != *" $CONFIG_REPO "* ]]; then
     REPOS="$CONFIG_REPO $REPOS"
 fi


### PR DESCRIPTION
Otherwise `CVMFS_CONFIG_REPOSITORY` looks like
```
/path/to/cvmfsexec/dist/etc/cvmfs/default.d/50-cern.conf:CVMFS_CONFIG_REPOSITORY=cvmfs-config.cern.ch
```
if more than one file is present in dist/etc/cvmfs/default.d.