### PR TITLE
Allow creating of fuse3-based distribution and support mount/unmount using fusermount3 if it is available

### DIFF
--- a/makedist
+++ b/makedist
@@ -10,8 +10,8 @@ SUPPORTEDTYPES="rhel7-x86_64 rhel8-aarch64 rhel8-x86_64 rhel8-ppc64le rhel9-x86_
 usage()
 {
     (
-    echo "Usage: makedist [-s] [ -m machinetype ] {osg|egi|default|none}"
-    echo "       makedist [-s] -o <self_extracting_script>"
+    echo "Usage: makedist [-s] [-3] [ -m machinetype ] {osg|egi|default|none}"
+    echo "       makedist [-s] [-3] -o <self_extracting_script>"
     echo " The first usage creates a distribution in 'dist' directory."
     echo "   The -m option selects machinetype for the distribution."
     echo "   The default is the current machine.  Supported types:"
@@ -22,11 +22,13 @@ usage()
     echo "   directory as the script."
     echo " The -s option makes both operations work for singcvmfs instead"
     echo "   of cvmfsexec, and files are left in .singcvmfs"
+    echo " The -3 option forces use of fuse3 backend for all machine types."
     ) >&2
     exit 2
 }
 
 SING=false
+FUSE3=false
 MACHTYPE=""
 while true; do
     if [ "$1" = "-s" ]; then
@@ -35,6 +37,9 @@ while true; do
     elif [ "$1" = "-m" ]; then
         MACHTYPE="$2"
         shift 2
+    elif [ "$1" = "-3" ]; then
+        FUSE3=true
+        shift
     else
         break
     fi
@@ -302,49 +307,66 @@ if $INCLUDEHELPER; then
 fi
 
 FUSESUBDIR=false
-CVMFSFUSE3URL="$CVMFSURL/`echo $CVMFSRPMNAME|sed 's/cvmfs-/cvmfs-fuse3-/'`"
+CVMFSFUSE3RPMNAME=`echo $CVMFSRPMNAME|sed 's/cvmfs-/cvmfs-fuse3-/'`
+CVMFSFUSE3URL="$CVMFSURL/$CVMFSFUSE3RPMNAME"
+
+USEFUSE3=false
 if $SING; then
+    USEFUSE3=true
+fi
+if $FUSE3; then
+    USEFUSE3=true
+fi
+if [ "$EL" -ge 9 ]; then
+    USEFUSE3=true
+fi
+
+if [ "$DISTRO" = suse ]; then
+    if $USEFUSE3; then
+        # hack to check if package is available in current dir
+        if [ ! -f "$HERE/$CVMFSFUSE3RPMNAME" ]; then
+            echo "No cvmfs-fuse3 for suse15 available." >&2
+            echo "Please provide custom-built $CVMFSFUSE3RPMNAME in the $HERE directory to continue." >&2
+            exit 1
+        else
+            CVMFSFUSE3URL="file://$HERE/$CVMFSFUSE3RPMNAME"
+        fi
+    fi
+fi
+
+if $USEFUSE3; then
     URLS="$URLS $CVMFSFUSE3URL"
+    FUSELIB=fuse3-libs
+else
+    FUSELIB=fuse-libs
+fi
+if [ "$DISTRO" = suse ]; then
+    FUSEURL="https://download.opensuse.org/distribution/openSUSE-stable/repo/oss/x86_64"
+    if $USEFUSE3; then
+        FUSELIB=libfuse3
+    else
+        FUSELIB=libfuse2
+    fi
+else
     if [ "$EL" -lt 8 ]; then
-        FUSEURL="https://archives.fedoraproject.org/pub/archive/epel/$EL/$ARCH/Packages"
-        FUSESUBDIR=true
+        if $USEFUSE3; then
+            FUSEURL="https://archives.fedoraproject.org/pub/archive/epel/$EL/$ARCH/Packages"
+            FUSESUBDIR=true
+        else
+            FUSEURL="https://vault.centos.org/centos/$EL/os/$ARCH/Packages/"
+        fi
     elif [ "$EL" -eq 8 ]; then
         FUSEURL="https://repo.almalinux.org/almalinux/$EL/BaseOS/$ARCH/os/Packages"
     else
         FUSEURL="https://repo.almalinux.org/almalinux/$EL/AppStream/$ARCH/os/Packages"
     fi
-    URL="`latesturl $FUSEURL fuse3-libs $FUSESUBDIR`"
-    if [ -z "$URL" ]; then
-        echo "No fuse3-libs package found from $FUSEURL" >&2
-        exit 1
-    fi
-    URLS="$URLS $URL"
-else
-    if [ "$DISTRO" = suse ]; then
-        FUSEURL="https://download.opensuse.org/distribution/openSUSE-stable/repo/oss/x86_64"
-        FUSELIB=libfuse2
-    else
-        if [ "$EL" -lt 8 ]; then
-            FUSEURL="https://vault.centos.org/centos/$EL/os/$ARCH/Packages/"
-        elif [ "$EL" -eq 8 ]; then
-            FUSEURL="https://repo.almalinux.org/almalinux/$EL/BaseOS/$ARCH/os/Packages"
-        else
-            FUSEURL="https://repo.almalinux.org/almalinux/$EL/AppStream/$ARCH/os/Packages"
-        fi
-        if [ "$EL" -lt 9 ]; then
-            FUSELIB=fuse-libs
-        else
-            FUSELIB=fuse3-libs
-            URLS="$URLS $CVMFSFUSE3URL"
-        fi
-    fi
-    URL="`latesturl $FUSEURL $FUSELIB $FUSESUBDIR`"
-    if [ -z "$URL" ]; then
-        echo "No $FUSELIB package found from $FUSEURL" >&2
-        exit 1
-    fi
-    URLS="$URLS $URL"
 fi
+URL="`latesturl $FUSEURL $FUSELIB $FUSESUBDIR`"
+if [ -z "$URL" ]; then
+    echo "No $FUSELIB package found from $FUSEURL" >&2
+    exit 1
+fi
+URLS="$URLS $URL"
 
 if [ "$EL" -eq 7 ]; then
     # add fuse2fs only on EL7, it is standard elsewhere

--- a/makedist
+++ b/makedist
@@ -28,7 +28,7 @@ usage()
 }
 
 SING=false
-FUSE3=false
+USEFUSE3=false
 MACHTYPE=""
 while true; do
     if [ "$1" = "-s" ]; then
@@ -38,7 +38,7 @@ while true; do
         MACHTYPE="$2"
         shift 2
     elif [ "$1" = "-3" ]; then
-        FUSE3=true
+        USEFUSE3=true
         shift
     else
         break
@@ -310,11 +310,7 @@ FUSESUBDIR=false
 CVMFSFUSE3RPMNAME=`echo $CVMFSRPMNAME|sed 's/cvmfs-/cvmfs-fuse3-/'`
 CVMFSFUSE3URL="$CVMFSURL/$CVMFSFUSE3RPMNAME"
 
-USEFUSE3=false
 if $SING; then
-    USEFUSE3=true
-fi
-if $FUSE3; then
     USEFUSE3=true
 fi
 if [ "$EL" -ge 9 ]; then

--- a/makedist
+++ b/makedist
@@ -325,7 +325,7 @@ if [ "$DISTRO" = suse ]; then
     if $USEFUSE3; then
         # hack to check if package is available in current dir
         if [ ! -f "$HERE/$CVMFSFUSE3RPMNAME" ]; then
-            echo "No cvmfs-fuse3 for suse15 available." >&2
+            echo "No cvmfs-fuse3 for SuSE available." >&2
             echo "Please provide custom-built $CVMFSFUSE3RPMNAME in the $HERE directory to continue." >&2
             exit 1
         else

--- a/mountrepo
+++ b/mountrepo
@@ -141,18 +141,16 @@ fi
 mkdir -p $DIST/var/run/cvmfs
 mkdir -p $DIST/cvmfs/$REPO
 if [ -f $DIST/usr/lib/libcvmfs_fuse.so ]; then
-    LPATH=$DIST/usr/lib
-    LDPATH=$LPATH
-    if [ ! -f $LPATH/libfuse.so.2 ]; then
-        # for el6
-        LDPATH=$LPATH:$DIST/lib
-    fi
+    LIBDIR=lib
 else
-    LPATH=$DIST/usr/lib64
-    LDPATH=$LPATH
+    LIBDIR=lib64
+fi
+LPATH=$DIST/usr/$LIBDIR
+LDPATH=$LPATH
+if [ ! -f $LPATH/libfuse3.so.3 ]; then
     if [ ! -f $LPATH/libfuse.so.2 ]; then
         # for el6
-        LDPATH=$LPATH:$DIST/lib64
+        LDPATH=$LPATH:$DIST/$LIBDIR
     fi
 fi
 LD_LIBRARY_PATH=$LDPATH CVMFS_LIBRARY_PATH=$LPATH $DIST/usr/bin/cvmfs2 -o config=$CONFFILE$OPTS $REPO $DIST/cvmfs/$REPO

--- a/umountrepo
+++ b/umountrepo
@@ -62,7 +62,13 @@ if [ "`id -u`" == 0 ]; then
     ISROOT=true
 else
     ISROOT=false
+    # detect fusermount helper available on the system
+    FUSERMOUNT=$(command -pv fusermount)
+    if [ -z "$FUSERMOUNT" ]; then
+        FUSERMOUNT=$(command -pv fusermount3)
+    fi
 fi
+
 
 for REPO; do
     if $LAZY; then
@@ -70,14 +76,14 @@ for REPO; do
         if $ISROOT; then
             umount -l $REPO
         else
-            fusermount -uz $REPO
+            $FUSERMOUNT -uz $REPO
         fi
     else
         echo "Unmounting $REPO"
         if $ISROOT; then
             umount $REPO
         else
-            fusermount -u $REPO
+            $FUSERMOUNT -u $REPO
         fi
         rmdir $REPO
     fi


### PR DESCRIPTION
In some HPC environments (e.g. PUHTI supercomputer) only fuse3 setuid-helper binary (fusermount3) is shipped on EL8.
Fuse2 libraries are still available but cannot be used in unprivileged way because of absence of setuid-helper, so the only solution is to use fuse3 variant of CVMFS.

This patch changes fuse3 support from apptainer-only to a generic option.